### PR TITLE
Fix LOAD CUE management

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -775,8 +775,10 @@ void CueControl::hotcueClear(HotcueControl* pControl, double v) {
     }
 
     CuePointer pCue(pControl->getCue());
-    detachCue(pControl->getHotcueNumber());
-    m_pLoadedTrack->removeCue(pCue);
+    if (pCue) {
+        detachCue(pControl->getHotcueNumber());
+        m_pLoadedTrack->removeCue(pCue);
+    }
 }
 
 void CueControl::hotcuePositionChanged(HotcueControl* pControl, double newPosition) {

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1031,7 +1031,12 @@ bool setTrackSampleRate(const QSqlRecord& record, const int column,
 
 bool setTrackCuePoint(const QSqlRecord& record, const int column,
                       TrackPointer pTrack) {
-    pTrack->setCuePoint(CuePosition(record.value(column).toDouble(), Cue::MANUAL));
+    Q_UNUSED(record);
+    Q_UNUSED(column);
+    Q_UNUSED(pTrack);
+    // The track's main cue point is stored in a separate cue object
+    // and no longer within the track itself. The corresponding table
+    // column is write-only to retain backward compatibility.
     return false;
 }
 

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -79,10 +79,12 @@ Cue::CueSource Cue::getSource() const {
 
 void Cue::setSource(CueSource source) {
     QMutexLocker lock(&m_mutex);
-    m_source = source;
-    m_bDirty = true;
-    lock.unlock();
-    emit(updated());
+    if (m_source != source) {
+        m_source = source;
+        m_bDirty = true;
+        lock.unlock();
+        emit updated();
+    }
 }
 
 Cue::CueType Cue::getType() const {
@@ -105,10 +107,12 @@ double Cue::getPosition() const {
 
 void Cue::setPosition(double samplePosition) {
     QMutexLocker lock(&m_mutex);
-    m_samplePosition = samplePosition;
-    m_bDirty = true;
-    lock.unlock();
-    emit(updated());
+    if (m_samplePosition != samplePosition) {
+        m_samplePosition = samplePosition;
+        m_bDirty = true;
+        lock.unlock();
+        emit updated();
+    }
 }
 
 double Cue::getLength() const {

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -115,6 +115,22 @@ void Cue::setPosition(double samplePosition) {
     }
 }
 
+CuePosition Cue::getCuePosition() const {
+    QMutexLocker lock(&m_mutex);
+    return CuePosition(m_samplePosition, m_source);
+}
+
+void Cue::setCuePosition(CuePosition position) {
+    QMutexLocker lock(&m_mutex);
+    if (CuePosition(m_samplePosition, m_source) != position) {
+        m_samplePosition = position.getPosition();
+        m_source = position.getSource();
+        m_bDirty = true;
+        lock.unlock();
+        emit updated();
+    }
+}
+
 double Cue::getLength() const {
     QMutexLocker lock(&m_mutex);
     return m_length;

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -784,7 +784,7 @@ CuePointer Track::findCueByType(Cue::CueType type) const {
 }
 
 void Track::removeCue(const CuePointer& pCue) {
-    if (pCue == nullptr) {
+    VERIFY_OR_DEBUG_ASSERT(pCue) {
         return;
     }
 

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -44,7 +44,6 @@ class TrackRecord final {
     PROPERTY_SET_BYVAL_GET_BYREF(QString,     fileType,       FileType)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,     url,            Url)
     PROPERTY_SET_BYVAL_GET_BYREF(PlayCounter, playCounter,    PlayCounter)
-    PROPERTY_SET_BYVAL_GET_BYREF(CuePosition, cuePoint,       CuePoint)
     PROPERTY_SET_BYVAL_GET_BYREF(int,         rating,         Rating)
     PROPERTY_SET_BYVAL_GET_BYREF(bool,        bpmLocked,      BpmLocked)
 


### PR DESCRIPTION
Hi,

I've fixed some issues with load/main cue management on master. But then I noticed that this would cause non-trivial merge conflicts :see_no_evil:

So I decided to redo those changes on your PR branch. Unfortunately 2 of the newly added tests fail and I'm not sure why. Maybe because the track's cue point is now reliably reset when a LOAD CUE is removed?

What follows is the (already written) description of my original PR that explains the issues:

I've noticed cyclic dependencies and inconsistencies when setting/removing the LOAD CUE. Special care has to be taken when setting the _load_ aka _main_ cue point for both the track and the cue object at a time to avoid cascading of signals or potential deadlocks and to keep both values in sync:
* The cue point is first set indirectly through the _load cue object_ leaving the _track object_ unmodified. The track object's cue point is adjusted implicitly **_after_** receiving the corresponding signal from the load cue object.
* When the _load cue_ is removed the track's _(main) cue point_ needs to be reset, too.