### PR TITLE
render duration of intro & outro ranges on overview waveforms

### DIFF
--- a/res/skins/Deere/deck_overview.xml
+++ b/res/skins/Deere/deck_overview.xml
@@ -41,12 +41,14 @@
       <EndControl>intro_end_position</EndControl>
       <Color>#0000FF</Color>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <DurationTextColor>#ffffff</DurationTextColor>
     </MarkRange>
     <MarkRange>
       <StartControl>outro_start_position</StartControl>
       <EndControl>outro_end_position</EndControl>
       <Color>#0000FF</Color>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <DurationTextColor>#ffffff</DurationTextColor>
     </MarkRange>
     <Mark>
       <Control>intro_start_position</Control>

--- a/res/skins/LateNight/deck_overview.xml
+++ b/res/skins/LateNight/deck_overview.xml
@@ -46,12 +46,14 @@
       <EndControl>intro_end_position</EndControl>
       <Color>#0000FF</Color>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <DurationTextColor>#ffffff</DurationTextColor>
     </MarkRange>
     <MarkRange>
       <StartControl>outro_start_position</StartControl>
       <EndControl>outro_end_position</EndControl>
       <Color>#0000FF</Color>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <DurationTextColor>#ffffff</DurationTextColor>
     </MarkRange>
     <Mark>
       <Control>intro_start_position</Control>

--- a/res/skins/Shade/deck_overview.xml
+++ b/res/skins/Shade/deck_overview.xml
@@ -32,12 +32,14 @@
       <EndControl>intro_end_position</EndControl>
       <Color>#0000FF</Color>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <DurationTextColor>#ffffff</DurationTextColor>
     </MarkRange>
     <MarkRange>
       <StartControl>outro_start_position</StartControl>
       <EndControl>outro_end_position</EndControl>
       <Color>#0000FF</Color>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <DurationTextColor>#ffffff</DurationTextColor>
     </MarkRange>
     <Mark>
       <Control>intro_start_position</Control>

--- a/res/skins/Tango/deck_overview.xml
+++ b/res/skins/Tango/deck_overview.xml
@@ -56,12 +56,14 @@ Variables:
       <EndControl>intro_end_position</EndControl>
       <Color>#0000FF</Color>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <DurationTextColor>#ffffff</DurationTextColor>
     </MarkRange>
     <MarkRange>
       <StartControl>outro_start_position</StartControl>
       <EndControl>outro_end_position</EndControl>
       <Color>#0000FF</Color>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <DurationTextColor>#ffffff</DurationTextColor>
     </MarkRange>
     <Mark>
       <Control>intro_start_position</Control>

--- a/src/waveform/renderers/waveformmarkrange.cpp
+++ b/src/waveform/renderers/waveformmarkrange.cpp
@@ -13,7 +13,8 @@ WaveformMarkRange::WaveformMarkRange(
         const SkinContext& context,
         const WaveformSignalColors& signalColors)
         : m_activeColor(context.selectString(node, "Color")),
-          m_disabledColor(context.selectString(node, "DisabledColor")) {
+          m_disabledColor(context.selectString(node, "DisabledColor")),
+          m_durationTextColor(context.selectString(node, "DurationTextColor")) {
     if (!m_activeColor.isValid()) {
         //vRince kind of legacy fallback ...
         // As a fallback, grab the mark color from the parent's MarkerColor
@@ -85,6 +86,10 @@ double WaveformMarkRange::end() const {
         end = m_markEndPointControl->get();
     }
     return end;
+}
+
+bool WaveformMarkRange::showDuration() const {
+    return m_durationTextColor.isValid() && start() != end() && start() != -1 && end() != -1;
 }
 
 void WaveformMarkRange::generateImage(int weidth, int height) {

--- a/src/waveform/renderers/waveformmarkrange.h
+++ b/src/waveform/renderers/waveformmarkrange.h
@@ -36,6 +36,8 @@ class WaveformMarkRange {
     // Returns end value or -1 if the end control doesn't exist.
     double end() const;
 
+    bool showDuration() const;
+
   private:
     void generateImage(int weidth, int height);
 
@@ -46,6 +48,7 @@ class WaveformMarkRange {
 
     QColor m_activeColor;
     QColor m_disabledColor;
+    QColor m_durationTextColor;
 
     QImage m_activeImage;
     QImage m_disabledImage;

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -92,6 +92,7 @@ class WOverview : public WWidget, public TrackDropTarget {
 
     void onMarkChanged(double v);
     void onMarkRangeChange(double v);
+    void onRateSliderChange(double v);
     void receiveCuesUpdated();
 
     void slotWaveformSummaryUpdated();
@@ -113,6 +114,10 @@ class WOverview : public WWidget, public TrackDropTarget {
     UserSettingsPointer m_pConfig;
     ControlProxy* m_endOfTrackControl;
     bool m_endOfTrack;
+    ControlProxy* m_pRateDirControl;
+    ControlProxy* m_pRateRangeControl;
+    ControlProxy* m_pRateSliderControl;
+    ControlProxy* m_trackSampleRateControl;
     ControlProxy* m_trackSamplesControl;
 
     // Current active track


### PR DESCRIPTION
MarkRange elements in skins only have their durations rendered if they specify a DurationTextColor. This avoids rendering the durations of loops on the overview waveform.

![image](https://user-images.githubusercontent.com/9455094/56545278-b6c02680-653c-11e9-9636-0f753728c057.png)

durations scale with rate slider:
![image](https://user-images.githubusercontent.com/9455094/56545312-d48d8b80-653c-11e9-8d91-1a0034f7f78e.png)
